### PR TITLE
Grant permissions to ServiceAccounts

### DIFF
--- a/rbac/managedclustersets/acm-grc-security/acm-grc-security.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/acm-grc-security/acm-grc-security.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: policy-grc-admins
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acm-grc-security'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/acm-observability-china/acm-observability-china.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/acm-observability-china/acm-observability-china.managedclusterset.rolebinding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: Core-Services
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acm-observability-china'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/acm-observability-usa/acm-observability-usa.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/acm-observability-usa/acm-observability-usa.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'Search-Admin'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:acm-observability-usa'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/app/app.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/app/app.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'AppLifecycle-Admins'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:app'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/cicd/cicd.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/cicd/cicd.managedclusterset.rolebinding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: CICD
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:cicd'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/cluster-lifecycle/cluster-lifecycle.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/cluster-lifecycle/cluster-lifecycle.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'cluster-lifecycle-team'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:cluster-lifecycle'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/console-squad/console-squad.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/console-squad/console-squad.managedclusterset.rolebinding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: console-squad
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:console-squad'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/far-edge/far-edge.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/far-edge/far-edge.managedclusterset.rolebinding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: far-edge
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:far-edge'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/install/install.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/install/install.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'installer-admin'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:install'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/kui-web-terminal/kui-web-terminal.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/kui-web-terminal/kui-web-terminal.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: squad-kui-Admins
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:kui-web-terminal'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/managed-services/managed-services.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/managed-services/managed-services.managedclusterset.rolebinding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: managed-services
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:managed-services'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/qe/qe.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/qe/qe.managedclusterset.rolebinding.yaml
@@ -12,6 +12,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: qe
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:qe'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/server-foundation/server-foundation.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/server-foundation/server-foundation.managedclusterset.rolebinding.yaml
@@ -9,6 +9,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'Server Foundation Admins'
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:server-foundation'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/rbac/managedclustersets/submariner/submariner.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/submariner/submariner.managedclusterset.rolebinding.yaml
@@ -6,6 +6,9 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: submariner
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:submariner'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
## Summary of Changes

This PR adds permissions to view and interact with pools and ManageClusterSets for all ServiceAccounts in each squad namespace.  