### PR TITLE
Fixing a copypasta error in app ManagedClusterSets

### DIFF
--- a/rbac/managedclustersets/app/app.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/app/app.managedclusterset.rolebinding.yaml
@@ -15,4 +15,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: open-cluster-management:managedclusterset:admin:cluster-lifecycle
+  name: open-cluster-management:managedclusterset:admin:app


### PR DESCRIPTION
## Summary of Changes

A copy-paste error occurred when setting up permissions for ManagedClusterSets for the `app` team - this patches that issue!  