### PR TITLE
Scope down the tennant-ocm-view ClusterRoleBinding to just a Role in the o-c-m namespace

### DIFF
--- a/rbac/open-cluster-management.view/tenants.ocm-view.rolebinding.yaml
+++ b/rbac/open-cluster-management.view/tenants.ocm-view.rolebinding.yaml
@@ -1,4 +1,4 @@
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tenants-ocm-view


### PR DESCRIPTION
## Summary of Changes

Update the tennant-ocm-view ClusterRoleBinding to a RoleBinding to lower the scope - this was the original intent, and fixes some viewership issues we encountered on `collective`.  