### PR TITLE
Add a demo ns and rolebinding

### DIFF
--- a/rbac/namespaces/demo/namespace.yaml
+++ b/rbac/namespaces/demo/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo

--- a/rbac/namespaces/demo/rolebinding.yaml
+++ b/rbac/namespaces/demo/rolebinding.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: demo-namespace-access
+  namespace: demo
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: demo
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:demo'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin


### PR DESCRIPTION
## Summary of Changes

We want to move Demo operations off of the meta cluster and onto collective - to accomplish this we want to drive configuration to the collective cluster as code for the demo namespace and group.  