### PR TITLE
Correct the managed-services squad name

### DIFF
--- a/rbac/managedclustersets/managed-services/managed-services.managedclusterset.rolebinding.yaml
+++ b/rbac/managedclustersets/managed-services/managed-services.managedclusterset.rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: managed-services
+    name: idp-for-the-masses
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: 'system:serviceaccounts:managed-services'


### PR DESCRIPTION
## Summary of Changes

This PR fixes a misnomer under the managed services namespace permissions.  